### PR TITLE
fix `npm run fmt` not working

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,8 @@
 {
-	"extends": "next/core-web-vitals",
+	"extends": [
+		"next/core-web-vitals",
+		"./kaboom/.eslintrc.json"
+	],
 	"ignorePatterns": ["kaboom"],
 	"plugins": ["@typescript-eslint"],
 	"rules": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,8 @@
 				"@types/node": "^20.11.17",
 				"@types/pako": "^2.0.3",
 				"@types/react": "^18.2.55",
-				"@typescript-eslint/eslint-plugin": "^5.0.0",
-				"@typescript-eslint/parser": "^5.0.0",
+				"@typescript-eslint/eslint-plugin": "^7.3.1",
+				"@typescript-eslint/parser": "^7.3.1",
 				"eslint": "^8.56.0",
 				"eslint-config-next": "^14.1.0",
 				"typescript": "^5.3.3"
@@ -886,32 +886,33 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
-			"integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.3.1.tgz",
+			"integrity": "sha512-STEDMVQGww5lhCuNXVSQfbfuNII5E08QWkvAw5Qwf+bj2WT+JkG1uc+5/vXA3AOYMDHVOSpL+9rcbEUiHIm2dw==",
 			"dev": true,
 			"dependencies": {
-				"@eslint-community/regexpp": "^4.4.0",
-				"@typescript-eslint/scope-manager": "5.62.0",
-				"@typescript-eslint/type-utils": "5.62.0",
-				"@typescript-eslint/utils": "5.62.0",
+				"@eslint-community/regexpp": "^4.5.1",
+				"@typescript-eslint/scope-manager": "7.3.1",
+				"@typescript-eslint/type-utils": "7.3.1",
+				"@typescript-eslint/utils": "7.3.1",
+				"@typescript-eslint/visitor-keys": "7.3.1",
 				"debug": "^4.3.4",
 				"graphemer": "^1.4.0",
-				"ignore": "^5.2.0",
-				"natural-compare-lite": "^1.4.0",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
+				"ignore": "^5.2.4",
+				"natural-compare": "^1.4.0",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^5.0.0",
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"@typescript-eslint/parser": "^7.0.0",
+				"eslint": "^8.56.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -920,25 +921,26 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
-			"integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.3.1.tgz",
+			"integrity": "sha512-Rq49+pq7viTRCH48XAbTA+wdLRrB/3sRq4Lpk0oGDm0VmnjBrAOVXH/Laalmwsv2VpekiEfVFwJYVk6/e8uvQw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.62.0",
-				"@typescript-eslint/types": "5.62.0",
-				"@typescript-eslint/typescript-estree": "5.62.0",
+				"@typescript-eslint/scope-manager": "7.3.1",
+				"@typescript-eslint/types": "7.3.1",
+				"@typescript-eslint/typescript-estree": "7.3.1",
+				"@typescript-eslint/visitor-keys": "7.3.1",
 				"debug": "^4.3.4"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"eslint": "^8.56.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -947,16 +949,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
-			"integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.3.1.tgz",
+			"integrity": "sha512-fVS6fPxldsKY2nFvyT7IP78UO1/I2huG+AYu5AMjCT9wtl6JFiDnsv4uad4jQ0GTFzcUV5HShVeN96/17bTBag==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.62.0",
-				"@typescript-eslint/visitor-keys": "5.62.0"
+				"@typescript-eslint/types": "7.3.1",
+				"@typescript-eslint/visitor-keys": "7.3.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -964,25 +966,25 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
-			"integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.3.1.tgz",
+			"integrity": "sha512-iFhaysxFsMDQlzJn+vr3OrxN8NmdQkHks4WaqD4QBnt5hsq234wcYdyQ9uquzJJIDAj5W4wQne3yEsYA6OmXGw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "5.62.0",
-				"@typescript-eslint/utils": "5.62.0",
+				"@typescript-eslint/typescript-estree": "7.3.1",
+				"@typescript-eslint/utils": "7.3.1",
 				"debug": "^4.3.4",
-				"tsutils": "^3.21.0"
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "*"
+				"eslint": "^8.56.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -991,12 +993,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-			"integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.3.1.tgz",
+			"integrity": "sha512-2tUf3uWggBDl4S4183nivWQ2HqceOZh1U4hhu4p1tPiIJoRRXrab7Y+Y0p+dozYwZVvLPRI6r5wKe9kToF9FIw==",
 			"dev": true,
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1004,21 +1006,22 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
-			"integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.3.1.tgz",
+			"integrity": "sha512-tLpuqM46LVkduWP7JO7yVoWshpJuJzxDOPYIVWUUZbW+4dBpgGeUdl/fQkhuV0A8eGnphYw3pp8d2EnvPOfxmQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.62.0",
-				"@typescript-eslint/visitor-keys": "5.62.0",
+				"@typescript-eslint/types": "7.3.1",
+				"@typescript-eslint/visitor-keys": "7.3.1",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
+				"minimatch": "9.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1030,65 +1033,66 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/utils": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
-			"integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 			"dev": true,
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.2.0",
-				"@types/json-schema": "^7.0.9",
-				"@types/semver": "^7.3.12",
-				"@typescript-eslint/scope-manager": "5.62.0",
-				"@typescript-eslint/types": "5.62.0",
-				"@typescript-eslint/typescript-estree": "5.62.0",
-				"eslint-scope": "^5.1.1",
-				"semver": "^7.3.7"
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@typescript-eslint/utils": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.3.1.tgz",
+			"integrity": "sha512-jIERm/6bYQ9HkynYlNZvXpzmXWZGhMbrOvq3jJzOSOlKXsVjrrolzWBjDW6/TvT5Q3WqaN4EkmcfdQwi9tDjBQ==",
+			"dev": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "7.3.1",
+				"@typescript-eslint/types": "7.3.1",
+				"@typescript-eslint/typescript-estree": "7.3.1",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/@typescript-eslint/utils/node_modules/eslint-scope": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-			"dev": true,
-			"dependencies": {
-				"esrecurse": "^4.3.0",
-				"estraverse": "^4.1.1"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/@typescript-eslint/utils/node_modules/estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4.0"
+				"eslint": "^8.56.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.62.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-			"integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.3.1.tgz",
+			"integrity": "sha512-9RMXwQF8knsZvfv9tdi+4D/j7dMG28X/wMJ8Jj6eOHyHWwDW4ngQJcqEczSsqIKKjFiLFr40Mnr7a5ulDD3vmw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.62.0",
-				"eslint-visitor-keys": "^3.3.0"
+				"@typescript-eslint/types": "7.3.1",
+				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2030,6 +2034,133 @@
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/eslint-config-next/node_modules/@typescript-eslint/parser": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+			"integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "6.21.0",
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/typescript-estree": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-config-next/node_modules/@typescript-eslint/scope-manager": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+			"integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/eslint-config-next/node_modules/@typescript-eslint/types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+			"integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+			"dev": true,
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/eslint-config-next/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+			"integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"minimatch": "9.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-config-next/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+			"integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "6.21.0",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/eslint-config-next/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/eslint-config-next/node_modules/minimatch": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/eslint-import-resolver-node": {
@@ -3728,12 +3859,6 @@
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
 		},
-		"node_modules/natural-compare-lite": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-			"dev": true
-		},
 		"node_modules/next": {
 			"version": "14.1.0",
 			"resolved": "https://registry.npmjs.org/next/-/next-14.1.0.tgz",
@@ -4875,6 +5000,18 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/ts-api-utils": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+			"integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.2.0"
+			}
+		},
 		"node_modules/tsconfig-paths": {
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -4891,27 +5028,6 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
 			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-		},
-		"node_modules/tsutils": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^1.8.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			},
-			"peerDependencies": {
-				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-			}
-		},
-		"node_modules/tsutils/node_modules/tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"dev": true
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
 				"@types/pako": "^2.0.3",
 				"@types/react": "^18.2.55",
 				"@typescript-eslint/eslint-plugin": "^7.3.1",
-				"@typescript-eslint/parser": "^7.3.1",
 				"eslint": "^8.56.0",
 				"eslint-config-next": "^14.1.0",
 				"typescript": "^5.3.3"
@@ -925,6 +924,7 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.3.1.tgz",
 			"integrity": "sha512-Rq49+pq7viTRCH48XAbTA+wdLRrB/3sRq4Lpk0oGDm0VmnjBrAOVXH/Laalmwsv2VpekiEfVFwJYVk6/e8uvQw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "7.3.1",
 				"@typescript-eslint/types": "7.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,8 @@
 				"@types/node": "^20.11.17",
 				"@types/pako": "^2.0.3",
 				"@types/react": "^18.2.55",
+				"@typescript-eslint/eslint-plugin": "^5.0.0",
+				"@typescript-eslint/parser": "^5.0.0",
 				"eslint": "^8.56.0",
 				"eslint-config-next": "^14.1.0",
 				"typescript": "^5.3.3"
@@ -822,6 +824,12 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/@types/json-schema": {
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+			"dev": true
+		},
 		"node_modules/@types/json5": {
 			"version": "0.0.29",
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -871,27 +879,66 @@
 			"integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
 			"dev": true
 		},
-		"node_modules/@typescript-eslint/parser": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-			"integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+		"node_modules/@types/semver": {
+			"version": "7.5.8",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+			"integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+			"dev": true
+		},
+		"node_modules/@typescript-eslint/eslint-plugin": {
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
+			"integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "6.21.0",
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/typescript-estree": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0",
-				"debug": "^4.3.4"
+				"@eslint-community/regexpp": "^4.4.0",
+				"@typescript-eslint/scope-manager": "5.62.0",
+				"@typescript-eslint/type-utils": "5.62.0",
+				"@typescript-eslint/utils": "5.62.0",
+				"debug": "^4.3.4",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.0",
+				"natural-compare-lite": "^1.4.0",
+				"semver": "^7.3.7",
+				"tsutils": "^3.21.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
+				"@typescript-eslint/parser": "^5.0.0",
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/parser": {
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
+			"integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "5.62.0",
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/typescript-estree": "5.62.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -900,29 +947,56 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-			"integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+			"integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0"
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/visitor-keys": "5.62.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
+		"node_modules/@typescript-eslint/type-utils": {
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
+			"integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/typescript-estree": "5.62.0",
+				"@typescript-eslint/utils": "5.62.0",
+				"debug": "^4.3.4",
+				"tsutils": "^3.21.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "*"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-			"integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+			"integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
 			"dev": true,
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -930,22 +1004,21 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-			"integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+			"integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0",
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/visitor-keys": "5.62.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
-				"minimatch": "9.0.3",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
+				"semver": "^7.3.7",
+				"tsutils": "^3.21.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -957,41 +1030,65 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+		"node_modules/@typescript-eslint/utils": {
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+			"integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
 			"dev": true,
 			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-			"dev": true,
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@types/json-schema": "^7.0.9",
+				"@types/semver": "^7.3.12",
+				"@typescript-eslint/scope-manager": "5.62.0",
+				"@typescript-eslint/types": "5.62.0",
+				"@typescript-eslint/typescript-estree": "5.62.0",
+				"eslint-scope": "^5.1.1",
+				"semver": "^7.3.7"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/utils/node_modules/eslint-scope": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"dev": true,
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/utils/node_modules/estraverse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-			"integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+			"version": "5.62.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+			"integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"eslint-visitor-keys": "^3.4.1"
+				"@typescript-eslint/types": "5.62.0",
+				"eslint-visitor-keys": "^3.3.0"
 			},
 			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3631,6 +3728,12 @@
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
 		},
+		"node_modules/natural-compare-lite": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+			"dev": true
+		},
 		"node_modules/next": {
 			"version": "14.1.0",
 			"resolved": "https://registry.npmjs.org/next/-/next-14.1.0.tgz",
@@ -4772,18 +4875,6 @@
 				"node": ">=14"
 			}
 		},
-		"node_modules/ts-api-utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
-			"integrity": "sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==",
-			"dev": true,
-			"engines": {
-				"node": ">=16"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.2.0"
-			}
-		},
 		"node_modules/tsconfig-paths": {
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -4800,6 +4891,27 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
 			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
+		"node_modules/tsutils": {
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+			"dev": true,
+			"dependencies": {
+				"tslib": "^1.8.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			},
+			"peerDependencies": {
+				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+			}
+		},
+		"node_modules/tsutils/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"dev": true
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 		"build": "node buildDoc.js && next build",
 		"start": "next start",
 		"lint": "next lint",
-		"fmt": "eslint --fix pages lib comps cm",
+		"fmt": "eslint --fix pages lib comps",
 		"check": "tsc --noEmit"
 	},
 	"dependencies": {
@@ -35,6 +35,8 @@
 		"@types/node": "^20.11.17",
 		"@types/pako": "^2.0.3",
 		"@types/react": "^18.2.55",
+		"@typescript-eslint/eslint-plugin": "^5.0.0",
+		"@typescript-eslint/parser": "^5.0.0",
 		"eslint": "^8.56.0",
 		"eslint-config-next": "^14.1.0",
 		"typescript": "^5.3.3"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
 		"@types/pako": "^2.0.3",
 		"@types/react": "^18.2.55",
 		"@typescript-eslint/eslint-plugin": "^7.3.1",
-		"@typescript-eslint/parser": "^7.3.1",
 		"eslint": "^8.56.0",
 		"eslint-config-next": "^14.1.0",
 		"typescript": "^5.3.3"

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
 		"@types/node": "^20.11.17",
 		"@types/pako": "^2.0.3",
 		"@types/react": "^18.2.55",
-		"@typescript-eslint/eslint-plugin": "^5.0.0",
-		"@typescript-eslint/parser": "^5.0.0",
+		"@typescript-eslint/eslint-plugin": "^7.3.1",
+		"@typescript-eslint/parser": "^7.3.1",
 		"eslint": "^8.56.0",
 		"eslint-config-next": "^14.1.0",
 		"typescript": "^5.3.3"


### PR DESCRIPTION
I was trying to use `npm run fmt` and it returned the following error:

```
> eslint --fix pages lib comps cm 

Oops! 
Something went wrong! :(  
ESLint: 8.56.0  
ESLint couldn't find the plugin "@typescript-eslint/eslint-plugin".  

(The package "@typescript-eslint/eslint-plugin" was not found when loaded as a Node module from the directory "/home/lajbel/gh/kaboomsite".)  

It's likely that the plugin isn't installed correctly. Try reinstalling by running the following:
npm install @typescript-eslint/eslint-plugin@latest --save-dev  

The plugin "@typescript-eslint/eslint-plugin" was referenced from the config file in ".eslintrc.json".
If you still can't figure out the problem, please stop by https://eslint.org/chat/help to chat with the team.
```

This PR fixes it.

- added `@typescript-eslint/eslint-plugin`
- updated `npm run fmt` to not fix in `cm` because it is already inside `lib`

BTW: Maybe you have to remove `node_modules` and run `npm i` to reproduce PR