### PR TITLE
add tutorial links in nav in doc/pages

### DIFF
--- a/comps/Nav.tsx
+++ b/comps/Nav.tsx
@@ -121,15 +121,15 @@ const IndexContentSection: React.FC<React.PropsWithChildren<{
 	sectionName: string;
 }>> = ({
 	children,
-	sectionName
+	sectionName,
 }) => (
-		<View stretchX gap={1} key={sectionName}>
-			<Text size="big" color={3}>{sectionName}</Text>
-			<View>
-				{children}
-			</View>
+	<View stretchX gap={1} key={sectionName}>
+		<Text size="big" color={3}>{sectionName}</Text>
+		<View>
+			{children}
 		</View>
-	)
+	</View>
+)
 
 const IndexContentItem: React.FC<{
 	title: string;
@@ -151,7 +151,7 @@ const IndexContentItem: React.FC<{
 			<Text color={2} code>{title}</Text>
 		</View>
 	</a>
-);
+)
 
 
 type SectionTuple = [string, string[]]

--- a/comps/Nav.tsx
+++ b/comps/Nav.tsx
@@ -1,22 +1,16 @@
 import * as React from "react"
 import Link from "next/link"
-import Image from "next/image"
 import { keyframes } from "@emotion/react"
 import { Info } from "react-feather"
-import fs from "fs/promises"
 import useMediaQuery from "hooks/useMediaQuery"
-import useClickOutside from "hooks/useClickOutside"
 import useUpdateEffect from "hooks/useUpdateEffect"
 import Background from "comps/Background"
 import View from "comps/View"
 import Text from "comps/Text"
-import Markdown from "comps/Markdown"
-import matter from "gray-matter"
 import Input from "comps/Input"
 import Drawer from "comps/Drawer"
 import ThemeSwitch from "comps/ThemeSwitch"
 import doc from "doc.json"
-import { GetServerSideProps } from "next"
 
 const popping = keyframes(`
 	0% {
@@ -123,36 +117,32 @@ const IndexContentSection: React.FC<React.PropsWithChildren<{
 	children,
 	sectionName,
 }) => (
-	<View stretchX gap={1} key={sectionName}>
-		<Text size="big" color={3}>{sectionName}</Text>
-		<View>
-			{children}
+		<View stretchX gap={1} key={sectionName}>
+			<Text size="big" color={3}>{sectionName}</Text>
+			<View>
+				{children}
+			</View>
 		</View>
-	</View>
-)
+	)
 
 const IndexContentItem: React.FC<{
 	title: string;
-	link: string;
 	shrink: () => void;
-}> = ({ title, shrink, link }) => (
-	<a href={`/${link}`}>
-		<View
-			padY={0.5}
-			onClick={shrink}
-			css={{
-				cursor: "pointer",
-				borderRadius: 8,
-				":hover": {
-					background: "var(--color-bg3)",
-				},
-			}}
-		>
-			<Text color={2} code>{title}</Text>
-		</View>
-	</a>
+}> = ({ title, shrink }) => (
+	<View
+		padY={0.5}
+		onClick={shrink}
+		css={{
+			cursor: "pointer",
+			borderRadius: 8,
+			":hover": {
+				background: "var(--color-bg3)",
+			},
+		}}
+	>
+		<Text color={2} code>{title}</Text>
+	</View>
 )
-
 
 type SectionTuple = [string, string[]]
 
@@ -225,12 +215,14 @@ const IndexContent: React.FC<IndexContentProps> = ({
 								const isFunc = mem.kind === "MethodSignature" || mem.kind === "FunctionDeclaration"
 
 								return (
-									<IndexContentItem
-										key={name}
-										title={`${name}${isFunc ? "()" : ""}`}
-										link={`#${name}`}
-										shrink={shrink}
-									/>
+
+									<a href={`/#${name}`} key={name}>
+										<IndexContentItem
+											title={`${name}${isFunc ? "()" : ""}`}
+											shrink={shrink}
+										/>
+									</a>
+
 								)
 							})}
 						</IndexContentSection>
@@ -241,12 +233,14 @@ const IndexContent: React.FC<IndexContentProps> = ({
 			{content == "tutorial" && (
 				<IndexContentSection sectionName={"Tutorials"}>
 					{contentItems?.filter(tutorial => query ? tutorial.title.match(new RegExp(query, "i")) : true).map((tutorial) => (
-						<IndexContentItem
-							key={tutorial.title}
-							title={tutorial.title}
-							link={tutorial.link}
-							shrink={shrink}
-						/>
+
+						<Link href={`/${tutorial.link}`} key={tutorial.title}>
+							<IndexContentItem
+								title={tutorial.title}
+								shrink={shrink}
+							/>
+						</Link>
+
 					))}
 				</IndexContentSection>
 			)}

--- a/pages/doc/[name].tsx
+++ b/pages/doc/[name].tsx
@@ -4,30 +4,71 @@ import Head from "comps/Head"
 import Markdown from "comps/Markdown"
 import Nav from "comps/Nav"
 import { capitalize } from "lib/str"
+import matter from "gray-matter"
+import { useMemo } from "react"
+
+const tutorialOrder = [
+	"setup",
+	"intro",
+	"comp",
+	"tips",
+]
 
 interface DocProps {
 	name: string,
 	src: string,
+	tutorials: any[],
 }
 
 const Doc: React.FC<DocProps> = ({
 	src,
 	name,
-}) => (
-	<Nav>
+	tutorials
+}) => {
+	const doc = useMemo(() => matter(src), [src])
+
+	return <Nav content="tutorial" contentItems={tutorials}>
 		<Head title={`Kaboom - ${capitalize(name)}`} />
-		<Markdown src={src} baseUrl="/static/doc/" />
+		<Markdown src={doc.content} baseUrl="/static/doc/" />
 	</Nav>
-)
+}
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
+	const tutorials = [];
+
+	for await (const tutorialEntry of await fs.readdir("public/static/doc")) {
+		if (!tutorialEntry.endsWith("md")) continue
+
+		const blog = await fs.readFile(`public/static/doc/${tutorialEntry}`, "utf8")
+		const data = matter(blog).data
+
+		data.link = `doc/${tutorialEntry.substring(0, tutorialEntry.length - 3)}`
+
+		tutorials.push(data)
+	}
+
+	tutorials.sort((a, b) => {
+		const aName = a.link.substring(4);
+		const bName = b.link.substring(4);
+
+		const aIndex = tutorialOrder.indexOf(aName)
+		const bIndex = tutorialOrder.indexOf(bName)
+
+		if (aIndex === -1) return 1
+		if (bIndex === -1) return -1
+
+		return aIndex - bIndex
+	})
+
 	const { name } = ctx.query
 	const path = `kaboom/doc/${name}.md`
+
 	try {
 		return {
 			props: {
 				name: name,
 				src: await fs.readFile(path, "utf8"),
+				tutorials,
 			},
 		}
 	} catch (e) {

--- a/pages/doc/[name].tsx
+++ b/pages/doc/[name].tsx
@@ -23,7 +23,7 @@ interface DocProps {
 const Doc: React.FC<DocProps> = ({
 	src,
 	name,
-	tutorials
+	tutorials,
 }) => {
 	const doc = useMemo(() => matter(src), [src])
 
@@ -34,7 +34,7 @@ const Doc: React.FC<DocProps> = ({
 }
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
-	const tutorials = [];
+	const tutorials = []
 
 	for await (const tutorialEntry of await fs.readdir("public/static/doc")) {
 		if (!tutorialEntry.endsWith("md")) continue
@@ -48,8 +48,8 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
 	}
 
 	tutorials.sort((a, b) => {
-		const aName = a.link.substring(4);
-		const bName = b.link.substring(4);
+		const aName = a.link.substring(4)
+		const bName = b.link.substring(4)
 
 		const aIndex = tutorialOrder.indexOf(aName)
 		const bIndex = tutorialOrder.indexOf(bName)


### PR DESCRIPTION
This PR has the objective of make all tutorials more accessible to users, exposing all them in the 
tutorials pages

![image](https://github.com/replit/kaboomsite/assets/71136486/d2eedd24-e9c4-48ce-9a21-3306816a6861)

This PR modifies the Nav component:

- Renamed Tutorial to Tutorials in Nav main links
- Move the documentation reference links to `IndexContentSection` and `IndexContentItem` components
- Nav now has two `content` modes, `tutorial` and `reference`
    - In `reference`, works as it already did
    - In `tutorial`, receives another prop `contentItems`, and wraps it inside a Section named Tutorials
- `pages/doc/[name].tsx` now also reads the markdowns of `doc/`, like `pages/blogs.tsx` do

## Post merge
I would like to organize the Nav component, splitting it in files, because due to this pr the file content increased, and it's becoming hardly readable. Maybe moving too the doc.json fetch to only run if the Nav content mode is `reference`
```
components/Nav/
    index.tsx # exports Nav by default
    Nav.tsx 
    Index.tsx
    IndexContent.tsx
    etc.tsx
```

Also fix this UX problem
![Animation](https://github.com/replit/kaboomsite/assets/71136486/0e810a95-79e4-4a1e-9f9c-46e3a1f920db)

